### PR TITLE
Add status_led and uptime components to YAML

### DIFF
--- a/firmware/transit-tracker.yaml
+++ b/firmware/transit-tracker.yaml
@@ -5,6 +5,7 @@ esphome:
   name: transit-tracker
   friendly_name: Transit Tracker
   name_add_mac_suffix: true
+  min_version: 2026.1.4
   project:
     name: "Eastside Urbanism.Transit Tracker"
     version: ${project_version}


### PR DESCRIPTION
PR for some easy quality of life improvements to the base YAML.  May only be useful for users that connect their system into HA (me).

1. status_led component
The Matrix Portal has a small onboard led for status indication.  This component ties it into the system status.

2. uptime sensor
There's already a time component set up in the configuration.  This component reports back when the system last booted.

3. min_version
This is the version that's specified in the release firmware workflow.  Makes sense to require it here for those of us compiling at home.