### PR TITLE
Adjust brightness behavior by specifying min_power

### DIFF
--- a/firmware/transit-tracker.yaml
+++ b/firmware/transit-tracker.yaml
@@ -197,8 +197,8 @@ output:
   - platform: template
     id: display_brightness_output
     type: float
-    min_power:  0.004 # 1/255
-    zero_means_zero: True
+    min_power: 0.004 # 1/255
+    zero_means_zero: true
     write_action:
       - hub75.set_brightness:
           id: matrix


### PR DESCRIPTION
PR to change the way that the lower end of the brightness setting works.

The default light gamma of 2.8 leaves the bottom 10% ([specifically 28/256](https://learn.adafruit.com/led-tricks-gamma-correction/the-longer-fix#perks-and-caveats-895296)) of the adjustment range set to zero.  This means in Home Assistant setting brightness to say 5% turns the display completely off.

Two additions change the behavior to more closely match what I would expect intuitively.  This is mostly an improvement for Home Assistant users, but from my testing the existing brightness up/down behavior remains unmodified.

1. Adding 1/255 as the `min_power` ensures that a brightness value <10% sets the display to it's lowest brightness instead of off.
2. `zero_means_zero: true` so that off still works to actually disable the display.