### PR TITLE
Fix now string typo

### DIFF
--- a/firmware/transit-tracker.yaml
+++ b/firmware/transit-tracker.yaml
@@ -133,7 +133,7 @@ text:
           id(tracker).set_route_styles_from_text(id(route_styles_config)->state);
   - <<: *config_text_common
     id: now_str_config
-    initial_value: "min"
+    initial_value: "Now"
     on_value:
       then:
         lambda: |-


### PR DESCRIPTION
This typo in the YAML was overriding "Now" with "min".

Changed to "Now" to match the default localization in https://github.com/tjhorner/esphome-transit-tracker/blob/03e5a01268e30fd85ec97e30bc21e9b88f8eb999/components/transit_tracker/localization.h#L28