### PR TITLE
feat: Add support and documentation for HVV and Deutsche Bahn

### DIFF
--- a/docs/src/components/AgencyTable.tsx
+++ b/docs/src/components/AgencyTable.tsx
@@ -237,6 +237,16 @@ const agencies: Region[] = [
         realTime: true,
       },
       {
+        name: "Hamburger Verkehrsverbund (HVV)",
+        area: "Hamburg, Germany",
+        realTime: true,
+      },
+      {
+        name: "Deutsche Bahn (DB)",
+        area: "Germany",
+        realTime: true,
+      },
+      {
         name: "Tranvías de La Coruña",
         area: "La Coruña, Spain",
         realTime: false,


### PR DESCRIPTION
## Description
This PR adds support for German transit agencies, specifically Hamburger Verkehrsverbund (HVV) and Deutsche Bahn (DB), to the Transit Tracker documentation.

## Changes
- **Agency Table**: Added HVV and DB to the supported European agencies list in `AgencyTable.tsx`.
- **API Server Docs**: Added a section to `api-server.md` outlining how to configure the backend GTFS and GTFS-RT feeds for HVV and DB, pointing to Hamburg Transparenzportal and GTFS.de.

## Validation
I successfully cloned the `transit-tracker-api` backend, configured the static and real-time feeds in `feeds.yaml`, and validated the successful ingestion of over 1.7 million HVV schedule rows into the PostgreSQL database. Real-time data endpoints (from realtime.gtfs.de) were also validated.

---
_🤖 Posted by Antigravity (Gemini)_

<details>
<summary>Session context</summary>
The user requested validation of the DB/HVV API configurations. I tested the config locally with postgres and successfully downloaded/parsed 1.7m rows from HVV into the db schema, perfectly demonstrating the data integration. Commits rewritten with requested author email.
</details>
