### PR TITLE
fix: apply ids to firmware OTA and update entries

### DIFF
--- a/firmware/transit-tracker.yaml
+++ b/firmware/transit-tracker.yaml
@@ -58,6 +58,7 @@ http_request:
 
 ota:
   - platform: http_request
+    id: ota_http_request
     on_begin:
       then:
         - display.page.show: ota_progress_page
@@ -77,10 +78,12 @@ ota:
         - lambda: id(ota_progress) = x;
         - component.update: matrix
   - platform: esphome
+    id: ota_esphome
     password: ""
 
 update:
   - platform: http_request
+    id: update_http_request
     name: Firmware Update
     source: https://transit-tracker.eastsideurbanism.org/firmware/manifest.json
     on_update_available:


### PR DESCRIPTION
## Summary:
Allow derived configurations to merge overrides into OTA/update entries. This enables things like the use of `!remove` to disable update mechanisms, or merging overrides like setting an `esphome` OTA update password.

I would like to be able to have my firmware by disable `update` and `ota.http_request`, as well as  be able to merge in an ESPHome OTA password.

---

## Verification:
`esphome config transit-tracker.yaml` to ensure the YAML is valid ESPHome configuration.

---

## Example usage:
```yaml
# Pin upstream package version
substitutions:
    github_ref: 45eb686a35cdaa2b9c0063f61a5a61e5aecdc0a7 # v3.3.0

packages:
    transit_tracker:
        url: https://github.com/EastsideUrbanism/transit-tracker
        path: firmware
        file: transit-tracker.yaml
        ref: ${github_ref}

esphome:
    name: transit-tracker
    friendly_name: Transit Tracker
    on_boot:
        priority: -100
        then:
            # Set initial brightness on boot
            - light.control:
                  id: display_brightness
                  brightness: 0.4%
                  state: ON

# Home assistant API key
api:
    encryption:
        key: !secret transit_api_encryption_key

# Disable auto-updates from web URL
update: !remove
script:
    - id: !remove update_firmware

# Disable firmware upload from webpage, require auth
web_server:
     ota: false
     auth:
         username: user
         password: !secret transit_web_password

# WiFi connection and override fallback captive AP password
wifi:
    ssid: !secret wifi_ssid
    password: !secret wifi_password
    ap:
        ssid: "${name}-Fallback-AP"
        password: !secret transit_ap_fallback_password

ota:
  # Disable HTTP OTA
  - id: !remove ota_http_request
  # Require password for ESPHome OTA
  - id: !extend ota_esphome
    password: !secret transit_ota_password

# Fix font file resolution when building against remote package
font:
    # Remove upstream reference to local path (which doesn't exist relative to this config)
    - id: !remove pixolletta
    # Replace with reference to the same asset URL directly on Github
    - id: pixolletta
      file: "https://github.com/EastsideUrbanism/transit-tracker/raw/${github_ref}/firmware/fonts/Pixolletta8px.ttf"
      size: 10
      glyphs:
          - abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,:;!?()"'-+/*=%@#[]{}<>|&^~
          - ÄËÏÖÜÉÈÔäëïöüéèôŊŋÁÊÎÛÝáêîûýĜĝÀÌÒàìòÑñÍÓÚíóúÇçĆČĐŠŽćčđšžÙùÕõŞŁŇŘşłňřÅåØøĀĒĪŌŪāēīōūÂâĞğıĎĚŤŮďěťůÆæĲĳŒœÐðŸÿßŐŰőűÞþÃãĂĔĬŎŬăĕĭŏŭĨŨĩũĄĘŃŚŻąęńśżĖėĢĶĻŅģķļņĮŲįųŔŹŕźĊĠċġħŜŝŢţŦŧŴŵŶŷĹĽĺľİ
          - " "

# Transit config
color:
    - id: "c_FDB71A"
      hex: "FDB71A"
    # ...
transit_tracker:
    base_url: "wss://tt.horner.tj/"
    time_display: "arrival"
    show_units: "none"
    list_mode: "sequential"
    scroll_headsigns: false
    stops:
        # ...
```